### PR TITLE
UPSTREAM: proc: make proc_fd_permission() thread-friendly

### DIFF
--- a/fs/proc/base.c
+++ b/fs/proc/base.c
@@ -2374,11 +2374,19 @@ static const struct file_operations proc_map_files_operations = {
  */
 static int proc_fd_permission(struct inode *inode, int mask)
 {
-	int rv = generic_permission(inode, mask);
+	struct task_struct *p;
+	int rv;
+
+	rv = generic_permission(inode, mask);
 	if (rv == 0)
-		return 0;
-	if (task_pid(current) == proc_pid(inode))
+		return rv;
+
+	rcu_read_lock();
+	p = pid_task(proc_pid(inode), PIDTYPE_PID);
+	if (p && same_thread_group(p, current))
 		rv = 0;
+	rcu_read_unlock();
+
 	return rv;
 }
 


### PR DESCRIPTION
Change proc_fd_permission() to check same_thread_group(pid_task(), current).
