### PR TITLE
maybe fix for vfp adopted by me

### DIFF
--- a/arch/arm/vfp/vfpmodule.c
+++ b/arch/arm/vfp/vfpmodule.c
@@ -731,9 +731,10 @@ static int __init vfp_init(void)
 {
 	unsigned int vfpsid;
 	unsigned int cpu_arch = cpu_architecture();
-#ifdef CONFIG_PROC_FS
-	static struct proc_dir_entry *procfs_entry;
-#endif
+
+
+
+
 	if (cpu_arch >= CPU_ARCH_ARMv6)
 		on_each_cpu(vfp_enable, NULL, 1);
 
@@ -802,8 +803,14 @@ static int __init vfp_init(void)
 				elf_hwcap |= HWCAP_VFPv4;
 		}
 	}
+	return 0;
+}
 
+static int __init vfp_rootfs_init(void)
+{
 #ifdef CONFIG_PROC_FS
+	static struct proc_dir_entry *procfs_entry;
+
 	procfs_entry = proc_create("cpu/vfp_bounce", S_IRUGO, NULL,
 			&vfp_bounce_fops);
 	if (!procfs_entry)
@@ -814,3 +821,4 @@ static int __init vfp_init(void)
 }
 
 core_initcall(vfp_init);
+rootfs_initcall(vfp_rootfs_init);


### PR DESCRIPTION
arm: vfpmodule: Fix warning procfs vfp_bounce reporting failed
Creation of procfs cpu/vfp_bounce fails because we're initialized too early. Fix this by creating it on rootfs_initcall as before the NEON patches.

Change-Id: Ic9bbe46ee026df0af76df70fd95275f284c8dd63 Signed-off-by: Paul Reioux reioux@gmail.com
